### PR TITLE
[bug] [patch] add missing key

### DIFF
--- a/src/client/reducers/index.js
+++ b/src/client/reducers/index.js
@@ -4,6 +4,11 @@ const number = (store) => {
   return store || {};
 };
 
+const checkBox = (store) => {
+  return store || {};
+};
+
 export default combineReducers({
-  number
+  number,
+  checkBox
 });


### PR DESCRIPTION
This removes the react warning about prop keys.